### PR TITLE
Issue #28: return NULL when key config is missing or has no provider

### DIFF
--- a/key.module
+++ b/key.module
@@ -658,8 +658,8 @@ function key_get_key_value($config) {
     $config = key_get_key($config_id);
   }
 
-  // If the configuration doesn't exist, return NULL.
-  if (!isset($config)) {
+  // config_get() returns [] for a missing config, so isset() doesn't help.
+  if (empty($config['key_provider'])) {
     return NULL;
   }
 

--- a/key.module
+++ b/key.module
@@ -646,7 +646,7 @@ function key_get_key_value($config) {
     $config_id = $config;
   }
   else {
-    $config_id = isset($config['id']) ? $config['id'] : '';
+    $config_id = $config['id'] ?? '';
   }
 
   // If the key has already been retrieved during this page load, return it.
@@ -654,11 +654,11 @@ function key_get_key_value($config) {
     return $keys[$config_id];
   }
 
-  if (!is_array($config)) {
+  if ($config_id && !is_array($config)) {
     $config = key_get_key($config_id);
   }
 
-  // config_get() returns [] for a missing config, so isset() doesn't help.
+  // If the configuration doesn't exist, return NULL.
   if (empty($config['key_provider'])) {
     return NULL;
   }


### PR DESCRIPTION
Closes #28.

When `key_get_key_value()` is called with a config id that doesn't exist (typo, never imported, deletion race), the current `if (!isset($config))` guard doesn't fire — Backdrop's `config_get()` returns `[]` (not `NULL` like D7's `variable_get`), so `isset` is TRUE. Execution falls through to `key_get_plugin('key_provider', NULL)` which returns the entire collection of providers, and `plugin_manager_get_function()` then tries to `require_once` the file plugin's full definition array as a path, fataling with `Failed opening required '…//Array'`.

This patches the guard to check for the presence of `key_provider` in the loaded config, which catches both the missing-config (`[]`) case and the malformed-config case.

Reproducer + full trace in #28.