### PR TITLE
Issue #30: allow overrides of key config

### DIFF
--- a/key.module
+++ b/key.module
@@ -416,12 +416,45 @@ function key_get_key_names_as_options($filters = array()) {
  *
  * @param string $id
  *   The machine name of the configuration to get.
+ * @param bool $override
+ *   TRUE if overrides (typically in the settings file) should be applied.
  *
  * @return array
  *   A key configuration.
  */
-function key_get_key($id) {
-  return config_get('key.key.' . $id);
+function key_get_key($id, $override = FALSE) {
+  $config = config('key.key.' . $id);
+  $config_data = $config->getData();
+
+  if ($override) {
+    $config_data = _key_set_key_overrides($config_data, $config);
+  }
+
+  return $config_data;
+}
+
+/**
+ * Recursive function to apply configuration overrides to the configuration
+ * data array.
+ *
+ * @param array $config_data
+ * @param Config $config
+ * @param string $chained_key_base
+ *
+ * @return array
+ */
+function _key_set_key_overrides(&$config_data, $config, $chained_key_base = '') {
+  foreach ($config_data as $key => $value) {
+    $chained_key = ($chained_key_base) ? $chained_key_base . '.' . $key : $key;
+    if (is_array($value)) {
+      $config_data[$key] = _key_set_key_overrides($config_data[$key], $config, $chained_key);
+    }
+    else {
+      $config_data[$key] = $config->get($chained_key);
+    }
+  }
+
+  return $config_data;
 }
 
 /**
@@ -566,7 +599,8 @@ function key_get_key_value($config) {
   }
 
   if ($config_id && !is_array($config)) {
-    $config = key_get_key($config_id);
+    // Include overrides.
+    $config = key_get_key($config_id, TRUE);
   }
 
   // If the configuration doesn't exist, return NULL.


### PR DESCRIPTION
fixes #30.

This is an alternative approach that hopefully addresses overrides like: `$config['example.settings']['foo.bar.key1'] = 'value1';` and `$config['example.settings']['foo'] = array('bar' => array('key1' => 'value1'));`.

I only found one instance where it seemed to make sense to allow an override, and that is when fetching the value with `key_get_key_value()`. Didn't want to have overrides when saving, deleting or loading into the config forms. Might be nice to show it's overridden somewhere but that can be a future issue.